### PR TITLE
Add multi lang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Reviewetの動作設定は```config/default.yml```を編集することで変更
 - 初回の通知対象に取得できたレビューをすべて含めるか：firstTimeIgnore
 - 初回表示で何件表示するか（未設定の場合は全件）：outputs
   - iOSは最新から、Androidはレビューの表示順からカウント
+- HTTP同時接続数の制限：maxConnections
 - Slack通知の利用設定：slack
 - Email通知の利用設定：email
 
@@ -74,6 +75,7 @@ cron:
 
 firstTimeIgnore: true
 outputs: 3
+maxConnections: 1
 ```
 
 #### 1. app
@@ -122,6 +124,12 @@ app:
 初回起動時に、存在するアプリレビューを何件表示するかのオプションです。  
 未設定の場合は
 ※firstTimeIgnoreの値が`true`の場合、この設定値は無視されます。
+
+#### 5. maxConnections
+
+HTTPの同時接続数を制限するオプションです。
+未設定の場合は制限されません。
+VPSの仕様などで同時接続数に制限がある場合に設定してください。
 
 ### to use Slack notification
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Reviewetの動作設定は```config/default.yml```を編集することで変更
 
 以下の内容が変更可能です。
 
-- レビューを取得するiOSアプリ：appId.iOS
-- レビューを取得するAndroidアプリ：appId.android
-- アプリレビューを取得する対象の言語：acceptLanguage
+- レビューを取得するiOSアプリ：app.iOS
+- レビューを取得するAndroidアプリ：app.android
+- アプリレビューを取得する対象の言語：app.iOS.countryCode, app.android.languageCode
 - cron指定による定期実行のタイミング制御（デフォルト1時間置きに実行）：cron
 - 初回の通知対象に取得できたレビューをすべて含めるか：firstTimeIgnore
 - 初回表示で何件表示するか（未設定の場合は全件）：outputs
@@ -61,10 +61,13 @@ Reviewetの動作設定は```config/default.yml```を編集することで変更
 ### Points of the changes
 
 ```yaml
-appId:
-  iOS: 490217893
-  android: com.google.android.googlequicksearchbox
-acceptLanguage: ja
+app:
+  iOS:
+    id: 490217893
+    countryCode: jp
+  android:
+    id: com.google.android.googlequicksearchbox
+    languageCode: ja
 cron:
   time: '0 * * * *'
   timeZone: Asia/Tokyo
@@ -73,44 +76,48 @@ firstTimeIgnore: true
 outputs: 3
 ```
 
-#### 1. appId  
+#### 1. app
 
-レビューを取得するアプリのIDを、iOSの場合はappIdの「iOS」に、Androidの場合は「android」に設定してください。（デフォルト値はサンプルです）  
-OS毎に複数のアプリのレビュー取得をすることも可能です。以下のようにリスト形式でIDを指定してください。
+レビューを取得するアプリのIDを、iOSの場合はappの「iOS」に、Androidの場合は「android」に設定してください。（デフォルト値はサンプルです）
+OS毎に複数のアプリ、複数の国（iOS）・国（android）のレビュー取得をすることも可能です。以下のようにリスト形式で指定してください。
 
 ```yaml
-appId:
+app:
   iOS:
-    - 490217893
-    - 544007664
+    - id: 490217893
+      countryCode: jp
+    - id: 544007664
+      countryCode:
+        - jp
+        - us
   android:
-    - com.google.android.googlequicksearchbox
-    - com.apple.android.music
+    - id: com.google.android.googlequicksearchbox
+      languageCode: ja
+    - id: com.apple.android.music
+      languageCode:
+        - fr
+        - it
 ```
 
-レビュー情報取得を利用しない場合は、対象のOSのappIdの値を空にしてください。  
+レビュー情報取得を利用しない場合は、対象のOSのappの値を空にしてください。
 （例えばGoogle Playからの情報を取得しない場合は```andorid: ```としてください）
 
-#### 2. acceptLanguage
+**※現在、app.android.languageCodeに日本（ja）以外を指定した場合、AndroidアプリレビューのRatingが取得できません。**
 
-レビューを取得するストアの言語を国別コードで指定してください。
-
-**※現在、acceptLanguageに日本（ja）以外を指定した場合、AndroidアプリレビューのRatingが取得できません。**
-
-#### 3. cron
+#### 2. cron
 
 本プログラムは1時間毎に定期実行されますが、実行タイミングをcron指定で変更することが可能です。
 変更する場合は、cronの「time」にcronの記述方法で設定してください。
 左から「秒(オプション)、分、時、日、月、週」になっています。  
 「timeZone」には、本プログラムを実行する環境のタイムゾーンを指定してください。
 
-#### 4. firstTimeIgnore
+#### 3. firstTimeIgnore
 
 初回起動時に、存在するレビュー結果を無視するかどうかのオプションです。  
 起動後の新着レビューだけの通知でよい場合は`true`に、
 存在しているレビューを通知させたい場合は`false`にしてください。
 
-#### 5. outputs
+#### 4. outputs
 
 初回起動時に、存在するアプリレビューを何件表示するかのオプションです。  
 未設定の場合は

--- a/config/default.yml
+++ b/config/default.yml
@@ -19,6 +19,7 @@ cron:
 
 firstTimeIgnore: true
 outputs: 3
+maxConnections:
 
 slack:
   use: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,6 +3,14 @@ appId:
   iOS: 490217893
   android: com.google.android.googlequicksearchbox
 acceptLanguage: ja
+# app:
+#   iOS:
+#     id: 490217893
+#     countryCode: jp
+#   android:
+#     id: com.google.android.googlequicksearchbox
+#     languageCode: ja
+
 cron:
   time: '0 * * * *'
   timeZone: Asia/Tokyo

--- a/config/default.yml
+++ b/config/default.yml
@@ -19,7 +19,7 @@ cron:
 
 firstTimeIgnore: true
 outputs: 3
-maxConnections:
+maxConnections: 1
 
 slack:
   use: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,9 @@ acceptLanguage: ja
 # app:
 #   iOS:
 #     id: 490217893
-#     countryCode: jp
+#     countryCode:
+#       - jp
+#       - us
 #   android:
 #     id: com.google.android.googlequicksearchbox
 #     languageCode: ja

--- a/src/main/AppData.js
+++ b/src/main/AppData.js
@@ -1,11 +1,14 @@
 /**
  * アプリのデータを保持するクラス
- * @param string kind ios or android
+ * @param {string} kind iOs or android
+ * @param {string} appId アプリID
+ * @param {string} langCountryCode 言語/国コード
  */
 export default class AppData {
-  constructor(kind, appId) {
+  constructor(kind, appId, langCountryCode) {
     this.kind = kind;
     this.appId = appId;
+    this.langCountryCode = langCountryCode;
     this.name = "";
     this.url = "";
     this.recentId = "";

--- a/src/main/Notification.js
+++ b/src/main/Notification.js
@@ -63,7 +63,12 @@ export default class Notification {
                 "title": "Version",
                 "value": this.reviewDatas[i].version,
                 "short": true
-              }
+              },
+              {
+                "title": "Language/Country",
+                "value": this.appData.langCountryCode,
+                "short": true
+              },
             ]
           }
         ]

--- a/src/main/Review.js
+++ b/src/main/Review.js
@@ -19,18 +19,20 @@ export default class Review {
     this.config = config;
     this.db = db;
 
-    // 国別コードの指定はjaをメインに、jpをサブにする。
-    this.lang = this.config.acceptLanguage;
-    this.lang_sub = this.lang;
-    if (this.lang === "ja") {
-      this.lang_sub = "jp"
-    } else if (this.lang === "jp") {
-      this.lang = "ja"
+    // 下位互換性
+    if (this.config.appId) {
+      // 国別コードの指定はjaをメインに、jpをサブにする。
+      this.lang = this.config.acceptLanguage;
+      this.lang_sub = this.lang;
+      if (this.lang === "ja") {
+        this.lang_sub = "jp"
+      } else if (this.lang === "jp") {
+        this.lang = "ja"
+      }
     }
 
     // 情報取得元のURLを生成
     this.ios_base_url = "http://itunes.apple.com/" + this.lang_sub + "/rss/customerreviews";
-
     // 初回通知しないオプション（起動後に設定されたレビュー結果を通知しないためのオプション）
     this.ignoreNotification = ignoreNotification;
 
@@ -53,32 +55,63 @@ export default class Review {
    * reviewetのメイン処理
    *
    * 指定されたiOS/AndroidのアプリIDに対して、レビューの取得処理を実施する。
-   * IDが指定されていないOSについては何もしない。
+   * 設定されていないOSについては何もしない。
    */
   main() {
-    let iosIds = this.config.appId.iOS;
-    if (iosIds !== null && !Array.isArray(iosIds)) {
-      iosIds = [iosIds];
+    if (this.config.appId) {
+      // 下位互換性
+      let iosIds = this.config.appId.iOS;
+      if (iosIds !== null && !Array.isArray(iosIds)) {
+        iosIds = [iosIds];
+      }
+      this.ios(iosIds.map(e => {
+        return {
+          id: e,
+          countryCode: this.lang_sub,
+        }
+      }));
+    } else {
+      let iosApps = this.config.app.iOS;
+      if (iosApps !== null && !Array.isArray(iosApps)) {
+        iosApps = [iosApps];
+      }
+      this.ios(iosApps);
     }
-    this.ios(iosIds);
 
-    let androidIds = this.config.appId.android;
-    if (androidIds !== null && !Array.isArray(androidIds)) {
-      androidIds = [androidIds];
+    if (this.config.appId) {
+      // 下位互換性
+      let androidIds = this.config.appId.android;
+      if (androidIds !== null && !Array.isArray(androidIds)) {
+        androidIds = [androidIds];
+      }
+      this.android(androidIds.map(e => {
+        return {
+          id: e,
+          languageCode: this.lang,
+        }
+      }));
+    } else {
+      let androidApps = this.config.app.android;
+      if (androidApps !== null && !Array.isArray(androidApps)) {
+        androidApps = [androidApps];
+      }
+      this.android(androidApps);
     }
-    this.android(androidIds);
   }
 
   /**
    * iOSのストアレビューを通知する
    *
-   * @param iosIds
+   * @param {array<Object>} iosApps アプリリスト
+   * @param {string} iosApp.id アプリID
+   * @param {string} iosApp.countryCode 国コード
    */
-  ios(iosIds) {
-    if (iosIds !== null) {
-      for (let i = 0; i < iosIds.length; i++) {
-        let iosId = iosIds[i];
-        let ios_url = this.createIosUrl(iosId, 1);
+  ios(iosApps) {
+    if (iosApps !== null) {
+      for (let i = 0; i < iosApps.length; i++) {
+        let iosId = iosApps[i].id;
+        let iosCountryCode = iosApps[i].countryCode;
+        let ios_url = this.createIosUrl(iosId, iosCountryCode);
         let iosApp = new AppData("iOS", iosId);
 
         // iOSアプリのレビューを通知
@@ -90,13 +123,16 @@ export default class Review {
   /**
    * Androidのストアレビューを通知する
    *
-   * @param androidIds
+   * @param {array<object>} androidApps アプリリスト
+   * @param {string} androidApp.id アプリID
+   * @param {string} androidApp.languageCode 言語コード
    */
-  android(androidIds) {
-    if (androidIds !== null) {
-      for (let i = 0; i < androidIds.length; i++) {
-        let androidId = androidIds[i];
-        let android_url = this.createAndroidUrl(androidId);
+  android(androidApps) {
+    if (androidApps !== null) {
+      for (let i = 0; i < androidApps.length; i++) {
+        let androidId = androidApps[i].id;
+        let androidLanguageCode = androidApps[i].languageCode;
+        let android_url = this.createAndroidUrl(androidId, androidLanguageCode);
         let androidApp = new AppData("Android", androidId);
 
         // Androidはストアサイトから直接データを取得するので、遷移先のURLにそのまま使う
@@ -149,15 +185,16 @@ export default class Review {
 
   /**
    * iOSアプリのレビューデータ取得元のURLを生成する。
-   * @param appId 取得対象アプリのAppStore ID
-   * @param page ページング
+   * @param {string} appId 取得対象アプリのAppStore ID
+   * @param {string} countryCode 取得対象アプリのAppStore国コード
+   * @param {number} page ページインデックス
    */
-  createIosUrl(appId, page) {
-    let url;
+  createIosUrl(appId, countryCode, page) {
+    let url = "http://itunes.apple.com/" + countryCode + "/rss/customerreviews";
     if (page !== null && page > 0) {
-      url = this.ios_base_url + "/page=" + page + "/id=" + appId + "/sortBy=mostRecent/xml";
+      url += "/page=" + page + "/id=" + appId + "/sortBy=mostRecent/xml";
     } else {
-      url = this.ios_base_url + "/id=" + appId + "/sortBy=mostRecent/xml";
+      url += "/id=" + appId + "/sortBy=mostRecent/xml";
     }
 
     return url;
@@ -165,10 +202,11 @@ export default class Review {
 
   /**
    * Androidアプリのレビューデータ取得元のURLを生成する。
-   * @param appId 取得対象アプリのGooglePlay ID
+   * @param {string} appId 取得対象アプリのGooglePlay ID
+   * @param {string} languageCode 取得対象アプリのGooglePlay言語コード
    */
-  createAndroidUrl(appId) {
-    return "https://play.google.com/store/apps/details?id=" + appId + "&hl=" + this.lang;
+  createAndroidUrl(appId, languageCode) {
+    return "https://play.google.com/store/apps/details?id=" + appId + "&hl=" + languageCode;
   }
 
   /**

--- a/src/main/Review.js
+++ b/src/main/Review.js
@@ -61,15 +61,17 @@ export default class Review {
     if (this.config.appId) {
       // 下位互換性
       let iosIds = this.config.appId.iOS;
-      if (iosIds !== null && !Array.isArray(iosIds)) {
-        iosIds = [iosIds];
-      }
-      this.ios(iosIds.map(e => {
-        return {
-          id: e,
-          countryCode: this.lang_sub,
+      if (iosIds) {
+        if (!Array.isArray(iosIds)) {
+          iosIds = [iosIds];
         }
-      }));
+        this.ios(iosIds.map(e => {
+          return {
+            id: e,
+            countryCode: [this.lang_sub],
+          }
+        }));
+      }
     } else {
       let iosApps = this.config.app.iOS;
       if (iosApps) {
@@ -89,15 +91,17 @@ export default class Review {
     if (this.config.appId) {
       // 下位互換性
       let androidIds = this.config.appId.android;
-      if (androidIds !== null && !Array.isArray(androidIds)) {
-        androidIds = [androidIds];
-      }
-      this.android(androidIds.map(e => {
-        return {
-          id: e,
-          languageCode: this.lang,
+      if (androidIds) {
+        if (!Array.isArray(androidIds)) {
+          androidIds = [androidIds];
         }
-      }));
+        this.android(androidIds.map(e => {
+          return {
+            id: e,
+            languageCode: [this.lang],
+          }
+        }));
+      }
     } else {
       let androidApps = this.config.app.android;
       if (androidApps) {

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -5,6 +5,7 @@ process.on('unhandledRejection', console.dir);
 // モジュールの取り込み
 import config from 'config';
 import { CronJob } from 'cron';
+import http from 'http';
 const sqlite3 = require('sqlite3').verbose();
 
 import Review from './Review';
@@ -34,6 +35,11 @@ db.serialize(function(){
     "PRIMARY KEY (id, kind))"
   );
 });
+
+// HTTPコネクション数の制限
+if (config.maxConnections) {
+  http.globalAgent.maxSockets = config.maxConnections
+}
 
 try {
 //  const CronJob = require('cron').CronJob;


### PR DESCRIPTION
アプリの各国（iOS）各言語（Android）のレビューを取れるように機能を追加しました．

* 設定に`appId`がある場合は以前の通りに動くように下位互換性を持たせています
* 設定に`app`（新設）がある場合はアプリ毎に設定された各国・各言語のレビューを取得します
    * iOSとAndroidとで指定が国・言語と違うのと，アプリ毎に公開地域が違うと思うので，アプリ毎に国・言語の設定を持たせるようにしました
* READMEは新設定のみの記述に変更しています
* iOSに関しては手元で確認していますが，Androidは確認できていません
    * Google PlayページのDOMが変わっているためか，私の環境では修正前の状態でもレビューが取れなかったです
* テストは元々無かったこともあり，入れていません．スイマセン．